### PR TITLE
Pull bundletester for now

### DIFF
--- a/install-review-tools.sh
+++ b/install-review-tools.sh
@@ -8,13 +8,12 @@ sudo apt-get install -qy \
                         charm \
                         charm-tools \
                         python-dev \
+                        python-flake8 \
                         python-pip \
                         python-virtualenv \
                         python-tox \
                         rsync \
                         unzip
-
-sudo pip install bundletester flake8 pyyaml --upgrade
 
 echo "export LAYER_PATH=${HOME}/layers" >> /home/ubuntu/.bashrc
 echo "export INTERFACE_PATH=${HOME}/interfaces" >> /home/ubuntu/.bashrc


### PR DESCRIPTION
Bundletester has its own suite of dependencies coming in now, and this will
need to be fully isolated in a virtualenv to keep system packages sane. Until bundletester is vett'd to work on 2.0 it seems like extra work, i'll circle back once the queue has cleared out a bit. Until then - this will resolve the charm-tools issue stemming in charmbox:devel

Prereq work to resolve the issue found in #18
