### PR TITLE
Disable strict hostkey checking for CI purposes

### DIFF
--- a/install-review-tools.sh
+++ b/install-review-tools.sh
@@ -10,7 +10,8 @@ sudo apt-get install -qy unzip \
                          python-pip \
                          python-virtualenv \
                          python-tox \
-                         rsync 
+                         rsync  \
+			 make
 sudo pip install bundletester flake8 pyyaml --upgrade
 
 # Fix for CI choking on duplicate hosts if the host key has changed

--- a/install-review-tools.sh
+++ b/install-review-tools.sh
@@ -13,4 +13,11 @@ sudo apt-get install -qy unzip \
                          rsync 
 sudo pip install bundletester flake8 pyyaml --upgrade
 
+# Fix for CI choking on duplicate hosts if the host key has changed
+# which is common. 
+mkdir -p $HOME/.ssh
+echo 'Host*:' > $HOME/.ssh/config
+echo '  StrictHostKeyChecking no' >> $HOME/.ssh/config
+
 chown -R ubuntu:ubuntu ${HOME}
+

--- a/install-review-tools.sh
+++ b/install-review-tools.sh
@@ -17,7 +17,7 @@ sudo pip install bundletester flake8 pyyaml --upgrade
 # Fix for CI choking on duplicate hosts if the host key has changed
 # which is common. 
 mkdir -p $HOME/.ssh
-echo 'Host*:' > $HOME/.ssh/config
+echo 'Host *' > $HOME/.ssh/config
 echo '  StrictHostKeyChecking no' >> $HOME/.ssh/config
 
 chown -R ubuntu:ubuntu ${HOME}


### PR DESCRIPTION
This should resolve an issue that has rissen up in CI where host keys are cached, and a duplicate IP is assigned to a new service, but has a new hostkey, which will result in a failure when amulet attempts to ssh into the unit to do work.
