### PR TITLE
use newer tox

### DIFF
--- a/install-review-tools.sh
+++ b/install-review-tools.sh
@@ -9,10 +9,9 @@ sudo apt-get install -qy unzip \
                          python-dev \
                          python-pip \
                          python-virtualenv \
-                         python-tox \
                          rsync  \
 			 make
-sudo pip install bundletester flake8 pyyaml --upgrade
+sudo pip install bundletester flake8 pyyaml tox --upgrade
 
 
 # Fix for CI choking on duplicate hosts if the host key has changed


### PR DESCRIPTION
use pip tox since we need tox>=1.8 to ignore py35 env on trusty (and we need py35 for xenial)
