### PR TITLE
install more recent tox

### DIFF
--- a/install-review-tools.sh
+++ b/install-review-tools.sh
@@ -22,10 +22,10 @@ sudo apt-get install -qy \
                         python-flake8 \
                         python-pip \
                         python-virtualenv \
-                        python-tox \
                         rsync \
                         unzip \
 			make
+sudo pip install tox --upgrade
 
 echo "export LAYER_PATH=${HOME}/layers" >> /home/ubuntu/.bashrc
 echo "export INTERFACE_PATH=${HOME}/interfaces" >> /home/ubuntu/.bashrc


### PR DESCRIPTION
python-tox is 1.6 and doesn't support "skip_missing_interpreter".  Use pip tox since we need tox>=1.8 to ignore py35 interpreter on trusty (and we need py35 for xenial).
