### PR TITLE
Proposal: Minimal delta between :latest and :devel

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM jujusolutions/jujubox:latest
+FROM jujusolutions/jujubox:devel
 
-VOLUME ["/home/ubuntu/.juju", "/home/ubuntu/trusty", "/home/ubuntu/precise"]
+VOLUME ["/home/ubuntu/.local/share/juju", "/home/ubuntu/trusty", "/home/ubuntu/xenial", "/home/ubuntu/layers", "/home/ubuntu/interfaces"
 RUN apt-get update -qy
 RUN apt-get install -qy gcc cython git make
 ADD install-review-tools.sh /install-review-tools.sh

--- a/install-review-tools.sh
+++ b/install-review-tools.sh
@@ -2,6 +2,8 @@
 set -e
 HOME=/home/ubuntu
 
+# Add tims awesome PPA for the 2.0 bleeding edge tooling
+sudo add-apt-repository -y ppa:tvansteenburgh/ppa
 sudo apt-get update -qqy
 sudo apt-get install -qy unzip \
                          build-essential\


### PR DESCRIPTION
Instead of furthering divergence between `:devel` and `:latest`, I propose this as a minimal delta.  This would replace the current `devel` branch (i.e., **do not merge this to `master`**), and we would keep it up to date with changes from `master` via rebase.  Any changes that must be done specifically for `:devel` should then be amended to this commit to keep the rebases as simple and clean as possible.
