### PR TITLE
Fix volume exports for latest docker behavior

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,10 @@
 FROM jujusolutions/jujubox:latest
 
-VOLUME ["/home/ubuntu/.juju", "/home/ubuntu/trusty", "/home/ubuntu/precise"]
+VOLUME "/home/ubuntu/.juju"
+VOLUME "/home/ubuntu/trusty"
+VOLUME "/home/ubuntu/builds"
+VOLUME "/home/ubuntu/layers"
+VOLUME "/home/ubuntu/interfaces"
 RUN apt-get update -qy
 RUN apt-get install -qy gcc cython git make
 ADD install-review-tools.sh /install-review-tools.sh


### PR DESCRIPTION
The recent version(s) of docker seem to interpret the array commas as
part of the path. This moves the volume declarations to one per line
which retains the expected behavior
