### PR TITLE
Target master branch for test tooling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,6 @@ VOLUME "/home/ubuntu/trusty"
 VOLUME "/home/ubuntu/builds"
 VOLUME "/home/ubuntu/layers"
 VOLUME "/home/ubuntu/interfaces"
-RUN apt-get update -qy
-RUN apt-get install -qy gcc cython git make
 ADD install-review-tools.sh /install-review-tools.sh
 RUN /install-review-tools.sh
 CMD /run.sh

--- a/install-review-tools.sh
+++ b/install-review-tools.sh
@@ -2,17 +2,31 @@
 set -e
 HOME=/home/ubuntu
 
+# Add tims awesome PPA for the 2.0 bleeding edge tooling
+sudo add-apt-repository -y ppa:tvansteenburgh/ppa
+
 sudo apt-get update -qqy
-sudo apt-get install -qy unzip \
-                         build-essential\
+sudo apt-get install -qy amulet \
+                         build-essential \
+                         cython \
                          charm-tools \
+                         git \
+                         make \
                          python-dev \
+                         python3-dev \
                          python-pip \
+                         python3-pip \
                          python-virtualenv \
                          rsync  \
-			 make
-sudo pip install bundletester flake8 pyyaml tox --upgrade
+                         unzip
 
+sudo pip install --upgrade pip
+sudo pip install --upgrade bundletester flake8 pyyaml tox
+
+git clone https://github.com/juju/amulet /tmp/amulet
+cd /tmp/amulet
+pip install --upgrade ./
+pip3 install --upgrade ./
 
 # Fix for CI choking on duplicate hosts if the host key has changed
 # which is common. 


### PR DESCRIPTION
- This moves the test tooling which is 2.x and 1.25 compat into the
  master branch
- Removes any traces of non-docker things in the Dockerfile
- Should be the foundation for a clean 1 line rebase with :devel branch

Pulls in @mbruzek's work started in #38, and caused #44 
