### PR TITLE
Refactor installation dependency chain

### DIFF
--- a/install-review-tools.sh
+++ b/install-review-tools.sh
@@ -3,26 +3,29 @@ set -e
 HOME=/home/ubuntu
 
 # Add tims awesome PPA for the 2.0 bleeding edge tooling
-sudo add-apt-repository -y ppa:tvansteenburgh/ppa
+add-apt-repository -y ppa:tvansteenburgh/ppa
 
 apt-get update -qqy
-apt-get install -qy amulet \
-                         build-essential \
-                         cython \
-                         charm-tools \
-                         git \
-                         libssl-dev \
-                         make \
-                         python-dev \
-                         python3-dev \
-                         python-pip \
-                         python3-pip \
-                         python-virtualenv \
-                         rsync  \
-                         unzip
+apt-get install -qy  \
+                     build-essential \
+                     cython \
+                     git \
+                     juju-deployer \
+                     libssl-dev \
+                     make \
+                     python-dev \
+                     python-jujuclient \
+                     python3-dev \
+                     python-pip \
+                     python3-pip \
+                     python-virtualenv \
+                     rsync  \
+                     unzip
+
+apt install --no-install-recommends charm
 
 pip install --upgrade pip
-pip install amulet flake8 bundletester tox
+pip install amulet charm-tools flake8 bundletester tox
 
 # Fix for CI choking on duplicate hosts if the host key has changed
 # which is common. 


### PR DESCRIPTION
I conferred with @marcoceppi this morning about the charm-tools and
charm dependency chain and the future facing move to snap delivery.

We're currently pressed as we cant deliver software via snaps inside
docker unless we're running systemd amenities. Docker doesn't play well
with running an init, so we're at an impass. Here's the current
packaging notes:
- Instal charm-tools from pypi. This will always be up to date with the
  latest stable release of charm-tools
- For now, install the charm command from apt, until we have the
  delivery pipeline sorted
- any derivative works should actively try not to unpin versioned
  dependencies such as pyyaml. So a simple `pip install` vs `pip
  install -U` will suffice.

This build was tested as a base for cwrbox and resolves the dependency
chain issues that surfaced on 8/30/2016
