### PR TITLE
Install/upgrade dependency six for bundletester

### DIFF
--- a/install-review-tools.sh
+++ b/install-review-tools.sh
@@ -24,7 +24,7 @@ apt-get install -qy  \
 
 apt install --no-install-recommends charm
 
-pip install --upgrade pip
+pip install --upgrade pip six
 pip install amulet charm-tools flake8 bundletester tox
 
 # Fix for CI choking on duplicate hosts if the host key has changed


### PR DESCRIPTION
Bundletester was complaining about missing dependency six, this minor tweak
fixes that complaint
