### PR TITLE
Add USER and WORKDIR

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,3 +5,6 @@ RUN /install-review-tools.sh
 # Override jujubox run.sh
 ADD run.sh /run.sh
 CMD /run.sh
+
+USER ubuntu
+WORKDIR /home/ubuntu


### PR DESCRIPTION
This eliminates some steps that I had to do everytime I wanted to use the charmbox
Before:
```
$ docker exec -it xxxxxxx bash
root@host:/# su ubuntu
welcome to juju 2.0
ubuntu@host:/$ cd
ubuntu@host:~$ 
```

After:
```
$ docker exec -it xxxxxxx bash
welcome to juju 2.0
ubuntu@host:~$
```

It also makes it easier to run commands directly:
`docker exec -u ubuntu xxxxxxx bash -c 'cd; some-command'`
becomes
`docker exec xxxxxxx some-command`