### PR TITLE
Move amulet to apt

### DIFF
--- a/install-review-tools.sh
+++ b/install-review-tools.sh
@@ -7,6 +7,7 @@ add-apt-repository -y ppa:tvansteenburgh/ppa
 
 apt-get update -qqy
 apt-get install -qy  \
+                     amulet \
                      build-essential \
                      cython \
                      git \
@@ -25,9 +26,7 @@ apt-get install -qy  \
 apt install --no-install-recommends charm
 
 pip install --upgrade pip six
-pip install amulet charm-tools flake8 bundletester tox
-pip3 install --upgrade pip
-pip3 install amulet
+pip install charm-tools flake8 bundletester tox
 
 # Fix for CI choking on duplicate hosts if the host key has changed
 # which is common. 


### PR DESCRIPTION
This needs 3rd party verification. I'm either under network issue, or there's an issue with my archive mirror. I'm currently getting:

```
charles@Tennoki ~/projects/work/charmbox $ docker build -t charmbox .
Sending build context to Docker daemon 13.31 kB
Step 1 : FROM jujusolutions/jujubox:latest
 ---> 1f823ae7b1a3
Step 2 : VOLUME "/home/ubuntu/.juju"
 ---> Using cache
 ---> f8639468bf03
Step 3 : VOLUME "/home/ubuntu/trusty"
 ---> Using cache
 ---> a98cda168550
Step 4 : VOLUME "/home/ubuntu/builds"
 ---> Using cache
 ---> 03f9cf240ea9
Step 5 : VOLUME "/home/ubuntu/layers"
 ---> Using cache
 ---> 5366d0985f10
Step 6 : VOLUME "/home/ubuntu/interfaces"
 ---> Using cache
 ---> 4861310c816b
Step 7 : ADD install-review-tools.sh /install-review-tools.sh
 ---> 1ffbbcb8778b
Removing intermediate container f5ba2450d927
Step 8 : RUN /install-review-tools.sh
 ---> Running in e5c0c156a671
gpg: keyring `/tmp/tmp_jtfh9ft/secring.gpg' created
gpg: keyring `/tmp/tmp_jtfh9ft/pubring.gpg' created
gpg: requesting key CB4C41BC from hkp server keyserver.ubuntu.com
gpg: /tmp/tmp_jtfh9ft/trustdb.gpg: trustdb created
gpg: key CB4C41BC: public key "Launchpad PPA for Tim Van Steenburgh" imported
gpg: Total number processed: 1
gpg:               imported: 1  (RSA: 1)
OK
W: Size of file /var/lib/apt/lists/archive.ubuntu.com_ubuntu_dists_trusty-updates_restricted_binary-amd64_Packages.gz is not what the server reported 20387 23469
W: Size of file /var/lib/apt/lists/archive.ubuntu.com_ubuntu_dists_trusty-security_restricted_binary-amd64_Packages.gz is not what the server reported 17042 20228
Reading package lists...
Building dependency tree...
Reading state information...
python-dev is already the newest version.
python-pip is already the newest version.
python-pip set to manually installed.
python-virtualenv is already the newest version.
python-virtualenv set to manually installed.
Some packages could not be installed. This may mean that you have
requested an impossible situation or if you are using the unstable
distribution that some required packages have not yet been created
or been moved out of Incoming.
The following information may help to resolve the situation:

The following packages have unmet dependencies:
 juju-deployer : Depends: python3-juju-deployer but it is not going to be installed
E: Unable to correct problems, you have held broken packages.
The command '/bin/sh -c /install-review-tools.sh' returned a non-zero code: 100

```

when I attempt to build the box.