### PR TITLE
add juju/stable to get latest version of charm

### DIFF
--- a/charmbox-setup.sh
+++ b/charmbox-setup.sh
@@ -20,6 +20,9 @@ sudo apt-get install -qy  \
                      rsync  \
                      unzip
 
+# Latest charm deb is in ppa:juju/stable, but our parent box (jujubox:devel)
+# only includes ppa:juju/devel. Add the stable ppa and install charm.
+sudo add-apt-repository -u -y ppa:juju/stable
 sudo apt install --no-install-recommends charm
 
 sudo pip install --upgrade pip six


### PR DESCRIPTION
Our parent box (jujubox:devel) only includes ppa:juju/devel. The latest
version of 'charm' lives in the stable ppa.  Add it before installing.
I looked into snap installing charm, but it requires socket stuff and the /run
dir that seemed non-trivial to get working in docker.