### PR TITLE
Install bundletester from source pending a pypi release

### DIFF
--- a/charmbox-setup.sh
+++ b/charmbox-setup.sh
@@ -23,9 +23,14 @@ sudo apt-get install -qy  \
 sudo apt install --no-install-recommends charm
 
 sudo pip install --upgrade pip six
-sudo pip install amulet flake8 bundletester tox
+sudo pip install amulet flake8 tox
 sudo pip3 install --upgrade pip
 sudo pip3 install amulet flake8
+
+# Install bundletester from source
+git clone https://github.com/juju-solutions/bundletester /tmp/bundletester
+cd /tmp/bundletester
+sudo pip2 install .
 
 # Install charm-tools from source
 git clone https://github.com/juju/charm-tools /tmp/charm-tools


### PR DESCRIPTION
This adds the --no-matrix flag to bundletester, which is why its being
installed from source. This is a temporary commit and can be safely
uncommited once bundletester reaches pypi