### PR TITLE
Revert bt from tip, add python3-flake8

### DIFF
--- a/charmbox-setup.sh
+++ b/charmbox-setup.sh
@@ -17,6 +17,7 @@ sudo apt-get install -qy  \
                      python-virtualenv \
                      python3-dev \
                      python3-pip \
+                     python3-flake8 \
                      rsync  \
                      unzip
 
@@ -25,7 +26,7 @@ sudo apt install --no-install-recommends charm
 sudo pip install --upgrade pip six
 sudo pip install amulet flake8 bundletester tox
 sudo pip3 install --upgrade pip
-sudo pip3 install amulet flake8
+sudo pip3 install amulet
 
 # Install charm-tools from source
 git clone https://github.com/juju/charm-tools /tmp/charm-tools

--- a/charmbox-setup.sh
+++ b/charmbox-setup.sh
@@ -23,14 +23,9 @@ sudo apt-get install -qy  \
 sudo apt install --no-install-recommends charm
 
 sudo pip install --upgrade pip six
-sudo pip install amulet flake8 tox
+sudo pip install amulet flake8 bundletester tox
 sudo pip3 install --upgrade pip
 sudo pip3 install amulet flake8
-
-# Install bundletester from source
-git clone https://github.com/juju-solutions/bundletester /tmp/bundletester
-cd /tmp/bundletester
-sudo pip2 install .
 
 # Install charm-tools from source
 git clone https://github.com/juju/charm-tools /tmp/charm-tools


### PR DESCRIPTION
This reverts commit 7c0fc46288be81cecbcc4916f862d03500cc8fc4.

The pip version wasn't functional when invoked via python3 -m flake8.
However the apt package was. Revert to archive for the time being.