### PR TITLE
devel changes back to master

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM jujusolutions/jujubox:latest
+FROM jujusolutions/jujubox:devel
 LABEL maintainer="kevin.monroe@canonical.com"
 
 ARG JUJU_USER=ubuntu

--- a/charmbox-setup.sh
+++ b/charmbox-setup.sh
@@ -21,6 +21,9 @@ sudo apt-get install -qy  \
                      rsync  \
                      unzip
 
+# Latest charm deb is in ppa:juju/stable, but our parent box (jujubox:devel)
+# only includes ppa:juju/devel. Add the stable ppa and install charm.
+sudo add-apt-repository -u -y ppa:juju/stable
 sudo apt install --no-install-recommends charm
 
 sudo pip install --upgrade pip six


### PR DESCRIPTION
The `devel` branch has been working well with recent changes.  Bring `master` up2date with relevant merges.